### PR TITLE
group is missing in the provision.yml playbook

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -26,6 +26,7 @@
       ec2_access_key: "{{ ec2_access_key }}"
       ec2_secret_key: "{{ ec2_secret_key }}"
       keypair: "{{ item.keypair }}"
+      group: "{{ item.group }}"
       instance_type: "{{ item.instance_type }}"
       image: "{{ item.image }}"
       instance_tags: "{{ item.instance_tags }}"


### PR DESCRIPTION
@tgerla please check it, group is missing in the provision.yml playbook, so whenever we create the instance it take the default security group. With this following PR, this problem resolved. Thanks for this nice aws example.
