### PR TITLE
removed bare variables

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -18,7 +18,7 @@
       region: "{{ ec2_region }}"
       ec2_access_key: "{{ ec2_access_key }}"
       ec2_secret_key: "{{ ec2_secret_key }}"
-    with_items: security_groups
+    with_items: "{{ security_groups }}"
 
   - name: Launch instances
     ec2: 
@@ -34,4 +34,4 @@
       count_tag: "{{ item.count_tag }}"
       wait: true
     register: ec2
-    with_items: ec2_instances
+    with_items: "{{ ec2_instances }}"


### PR DESCRIPTION
ansible 2 was complaining about the use of bare variables. As a newcomer to ansible, I found that  confusing so I thought you might appreciate this little update. 